### PR TITLE
added history paralleization

### DIFF
--- a/main.c
+++ b/main.c
@@ -719,7 +719,7 @@ int main (int argc, char **argv) {
             
         }
         int ihist;
-        #pragma omp parallel for firstprivate(ihist,nperbatch) schedule(dynamic)
+        #pragma omp parallel for schedule(dynamic)
         for (ihist=0; ihist<nperbatch; ihist++) {
             /* Initialize particle history */
             initHistory(ihist);
@@ -1595,8 +1595,10 @@ void accumulateResults(int iout, int nhist, int nbatch)
     /* Calculate incident fluence */
     double inc_fluence = (double)nhist;
     double mass;
-            
-    for (int iz=0; iz<geometry.ksize; iz++) {
+    int iz;
+
+    #pragma omp parallel for private(irl,endep,endep2,unc_endep,mass)
+    for (iz=0; iz<geometry.ksize; iz++) {
         for (int iy=0; iy<geometry.jsize; iy++) {
             for (int ix=0; ix<geometry.isize; ix++) {
                 irl = 1 + ix + iy*imax + iz*ijmax;
@@ -1648,7 +1650,8 @@ void accumulateResults(int iout, int nhist, int nbatch)
     }
     
     /* Zero dose in air */
-    for (int iz=0; iz<geometry.ksize; iz++) {
+    #pragma omp parallel for private(irl,endep,endep2,unc_endep,mass)
+    for (iz=0; iz<geometry.ksize; iz++) {
         for (int iy=0; iy<geometry.jsize; iy++) {
             for (int ix=0; ix<geometry.isize; ix++) {
                 irl = 1 + ix + iy*imax + iz*ijmax;
@@ -1757,7 +1760,7 @@ void ausgab(double edep) {
     double endep = stack.wt[np]*edep;
     
     /* Deposit particle energy on spot */
-	#pragma omp atomic
+	  #pragma omp atomic
     score.endep[irl] += endep;
     
     return;

--- a/matRad_ompInterface.c
+++ b/matRad_ompInterface.c
@@ -490,8 +490,8 @@ void mexFunction(
             
             //Set new nzmax and reallocate more memory
             mxSetNzmax(plhs[0], nzmax);
-            mxSetPr(plhs[0], mxRealloc(sr, nzmax*sizeof(double)));
-            mxSetIr(plhs[0], mxRealloc(irs, nzmax*sizeof(int)));
+            mxSetPr(plhs[0], (double *) mxRealloc(sr, nzmax*sizeof(double)));
+            mxSetIr(plhs[0], (mwIndex *)  mxRealloc(irs, nzmax*sizeof(mwIndex)));
             
             //Use the new pointers
             sr  = mxGetPr(plhs[0]);

--- a/matRad_ompInterface.c
+++ b/matRad_ompInterface.c
@@ -446,9 +446,9 @@ void mexFunction(
 //                        (double)(clock() - tbegin)/CLOCKS_PER_SEC, rng.ixx, rng.jxx);
 // 
 //             }
-			int ihist;
-			#pragma omp parallel for firstprivate(ihist,nperbatch) schedule(dynamic)
-			for (ihist=0; ihist<nperbatch; ihist++) {
+			      int ihist;
+			      #pragma omp parallel for schedule(dynamic)
+			      for (ihist=0; ihist<nperbatch; ihist++) {
                 /* Initialize particle history */	
 				        initHistory(ibeamlet);
 
@@ -532,7 +532,7 @@ void mexFunction(
         
         /* Reset accum_endep for following beamlet */
         memset(score.accum_endep, 0.0, (gridsize + 1)*sizeof(double));
-        
+                
 		    double progress = (double) (ibeamlet+1) / (double) source.nbeamlets;
 		
 		    //Update the waitbar with waitbar(hWaitbar,progress);


### PR DESCRIPTION
Hi Edgardo,
here is my more ore less trivial parallelization. I just made a pull request to make you aware of the changes, you don't have to accept the changes.
I made the stack and random number generator threadprivate, so that each history thread has its own. I added one atomic add in the ausgab function (don't know if more are required).

Also, in the interface, I redirected prinftf's, because they seem to cause crashes in multithreaded mex files wenn they are replaced with mexPrintf.